### PR TITLE
Adding the toml file for site 'SoundCloud'

### DIFF
--- a/data/apps/soundcloud.toml
+++ b/data/apps/soundcloud.toml
@@ -1,0 +1,4 @@
+name="SoundCloud"
+appsURL="https://soundcloud.com/settings"
+backgroundColor="#FF6D00"
+foregroundColor="#ffffff"


### PR DESCRIPTION
SoundCloud does not have a separate page for connected apps, but it has a section in the main setting page for it. That section does not have ID in HTML to de added to the URL, so this is what we get so far.